### PR TITLE
returning version info at /info/supported URL

### DIFF
--- a/src/guidescan_web/routes.clj
+++ b/src/guidescan_web/routes.clj
@@ -108,7 +108,8 @@
   {:supported [{:organism :enzyme}]}"
   [req config]
   (timbre/info "Info request from " (:remote-addr req) ".")
-  (let [json-obj {:available (keys (:grna-database-path-map (:config config)))}]
+  (let [json-obj {:version (-> "project.clj" slurp read-string (nth 2))
+                  :available (keys (:grna-database-path-map (:config config)))}]
     (content-type 
      (response (cheshire/encode json-obj))
      (render/get-content-type :json))))


### PR DESCRIPTION
I've added a version string to return along with the rest of the info at the `/info/supported` endpoint. This will come in handy once the frontend code starts pulling it in and displaying it in the UI.